### PR TITLE
GDF File Parser & Weapons Loaded on Vehicles

### DIFF
--- a/Assets/Scripts/System/CacheManager.cs
+++ b/Assets/Scripts/System/CacheManager.cs
@@ -259,7 +259,8 @@ namespace Assets.System
             {
                 foreach (GeoFace face in cacheEntry.GeoMesh.Faces)
                 {
-                    if (TextureParser.MaskTextureCache.TryGetValue(face.TextureName, out maskTexture))
+                    string textureName = face.TextureName + ".MAP";
+                    if (TextureParser.MaskTextureCache.TryGetValue(textureName, out maskTexture))
                     {
                         return true;
                     }
@@ -319,17 +320,6 @@ namespace Assets.System
             var carObject = Instantiate(CarPrefab); //ImportGeo(vdf.SOBJGeoName + ".geo", vtf, CarPrefab.gameObject).GetComponent<ArcadeCar>();
             carObject.gameObject.name = vdf.Name + " (" + vcf.VariantName + ")";
 
-            Transform[] weaponMountTransforms = new Transform[vdf.HLocs.Count];
-            for (int i = 0; i < vdf.HLocs.Count; ++i)
-            {
-                HLoc hloc = vdf.HLocs[i];
-                Transform mountPoint = new GameObject(hloc.Label).transform;
-                mountPoint.parent = carObject.transform;
-                mountPoint.localRotation = Quaternion.LookRotation(hloc.Forward, hloc.Up);
-                mountPoint.localPosition = hloc.Position;
-                weaponMountTransforms[i] = mountPoint;
-            }
-
             foreach (var vLoc in vdf.VLocs)
             {
                 var vlocGo = new GameObject("VLOC");
@@ -343,6 +333,17 @@ namespace Assets.System
 
             var thirdPerson = new GameObject("ThirdPerson");
             thirdPerson.transform.parent = chassis.transform;
+
+            Transform[] weaponMountTransforms = new Transform[vdf.HLocs.Count];
+            for (int i = 0; i < vdf.HLocs.Count; ++i)
+            {
+                HLoc hloc = vdf.HLocs[i];
+                Transform mountPoint = new GameObject(hloc.Label).transform;
+                mountPoint.parent = thirdPerson.transform;
+                mountPoint.localRotation = Quaternion.LookRotation(hloc.Forward, hloc.Up);
+                mountPoint.localPosition = hloc.Position;
+                weaponMountTransforms[i] = mountPoint;
+            }
 
             var firstPerson = new GameObject("FirstPerson");
             firstPerson.transform.parent = chassis.transform;

--- a/Assets/Scripts/System/CacheManager.cs
+++ b/Assets/Scripts/System/CacheManager.cs
@@ -378,11 +378,14 @@ namespace Assets.System
 
             for (int i = 0; i < vcf.Weapons.Count; ++i)
             {
-                Transform weaponTransform = new GameObject(vcf.Weapons[i].Gdf.Name).transform;
-                weaponTransform.SetParent(weaponMountTransforms[i]);
-                weaponTransform.localPosition = Vector3.zero;
-                weaponTransform.localRotation = Quaternion.identity; 
-                ImportCarParts(weaponTransform.gameObject, vtf, vcf.Weapons[i].Gdf.Parts, NoColliderPrefab, false);
+                if (vcf.Weapons[i].Gdf.Parts != null && vcf.Weapons[i].Gdf.Parts.Length > 0)
+                {
+                    Transform weaponTransform = new GameObject(vcf.Weapons[i].Gdf.Name).transform;
+                    weaponTransform.SetParent(weaponMountTransforms[i]);
+                    weaponTransform.localPosition = Vector3.zero;
+                    weaponTransform.localRotation = Quaternion.identity;
+                    ImportCarParts(weaponTransform.gameObject, vtf, vcf.Weapons[i].Gdf.Parts, NoColliderPrefab, false);
+                }
             }
 
             // Note: The following is probably how I76 does collision detection. Two large boxes that encapsulate the entire vehicle.

--- a/Assets/Scripts/System/Fileparsers/GdfParser.cs
+++ b/Assets/Scripts/System/Fileparsers/GdfParser.cs
@@ -1,0 +1,53 @@
+﻿using UnityEngine;
+
+namespace Assets.Fileparsers
+{
+    public class Gdf
+    {
+        public string Name { get; set; }
+        public string FireSpriteName { get; set; }
+        public string SoundName { get; set; }
+        public string EnabledSpriteName { get; set; }
+        public string DisabledSpriteName { get; set; }
+    }
+
+    class GdfParser
+    {
+        public static Gdf ParseGdf(string filename)
+        {
+            using (var br = new Bwd2Reader(filename))
+            {
+                var gdf = new Gdf();
+
+                br.FindNext("GDFC"); // 128 bytes
+                gdf.Name = br.ReadCString(16);
+                int unk1 = br.ReadInt32();
+                int unk2 = br.ReadInt32();
+                float unk3 = br.ReadSingle();
+                float unk4 = br.ReadSingle();
+                float unk5 = br.ReadSingle();
+                br.ReadBytes(20);
+                string unk6 = br.ReadCString(13);
+                br.ReadBytes(33);
+                gdf.FireSpriteName = br.ReadCString(13);
+                gdf.SoundName = br.ReadCString(13);
+                int unk7 = br.ReadInt32(); // Always 1?
+                gdf.EnabledSpriteName = br.ReadCString(16);
+                gdf.DisabledSpriteName = br.ReadCString(16);
+
+                br.FindNext("GPOF"); // 192 bytes
+
+
+                br.FindNext("GGEO"); // 4 bytes
+
+
+                br.FindNext("ORDF"); // 133 bytes
+
+
+                br.FindNext("OGEO"); // 104 bytes
+
+                return gdf;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/System/Fileparsers/GdfParser.cs
+++ b/Assets/Scripts/System/Fileparsers/GdfParser.cs
@@ -9,6 +9,7 @@ namespace Assets.Fileparsers
         public int FireAmount { get; set; }
         public float FiringRate { get; set; }
         public int AmmoCount { get; set; }
+        public float WeaponMass { get; set; }
         public string FireSpriteName { get; set; }
         public string SoundName { get; set; }
         public string EnabledSpriteName { get; set; }
@@ -41,7 +42,7 @@ namespace Assets.Fileparsers
                     br.ReadBytes(8);
                     int unk6 = br.ReadInt32();
                     gdf.Fireproofing = br.ReadInt32();
-                    float unk7 = br.ReadSingle();
+                    gdf.WeaponMass = br.ReadSingle();
                     string unk8 = br.ReadCString(13);
                     br.ReadBytes(9);
                     gdf.FiringRate = 1f / br.ReadSingle();

--- a/Assets/Scripts/System/Fileparsers/GdfParser.cs
+++ b/Assets/Scripts/System/Fileparsers/GdfParser.cs
@@ -5,13 +5,18 @@ namespace Assets.Fileparsers
     public class Gdf
     {
         public string Name { get; set; }
+        public int Fireproofing { get; set; }
+        public int FireAmount { get; set; }
+        public float FiringRate { get; set; }
+        public int AmmoCount { get; set; }
         public string FireSpriteName { get; set; }
         public string SoundName { get; set; }
         public string EnabledSpriteName { get; set; }
         public string DisabledSpriteName { get; set; }
+        public SdfPart[] Parts { get; set; }
     }
-
-    class GdfParser
+    
+    public class GdfParser
     {
         public static Gdf ParseGdf(string filename)
         {
@@ -19,28 +24,67 @@ namespace Assets.Fileparsers
             {
                 var gdf = new Gdf();
 
-                br.FindNext("GDFC"); // 128 bytes
-                gdf.Name = br.ReadCString(16);
-                int unk1 = br.ReadInt32();
-                int unk2 = br.ReadInt32();
-                float unk3 = br.ReadSingle();
-                float unk4 = br.ReadSingle();
-                float unk5 = br.ReadSingle();
-                br.ReadBytes(20);
-                string unk6 = br.ReadCString(13);
-                br.ReadBytes(33);
-                gdf.FireSpriteName = br.ReadCString(13);
-                gdf.SoundName = br.ReadCString(13);
-                int unk7 = br.ReadInt32(); // Always 1?
-                gdf.EnabledSpriteName = br.ReadCString(16);
-                gdf.DisabledSpriteName = br.ReadCString(16);
+                br.FindNext("REV");
+                int rev = br.ReadInt32();
+
+                br.FindNext("GDFC");
+                {
+                    gdf.Name = br.ReadCString(16);
+                    int unk1 = br.ReadInt32();
+                    int unk2 = br.ReadInt32();
+                    float unk3 = br.ReadSingle();
+                    float unk4 = br.ReadSingle();
+                    float unk5 = br.ReadSingle();
+                    br.ReadBytes(8);
+                    int unk6 = br.ReadInt32();
+                    gdf.Fireproofing = br.ReadInt32();
+                    float unk7 = br.ReadSingle();
+                    string unk8 = br.ReadCString(13);
+                    br.ReadBytes(9);
+                    gdf.FiringRate = 1f / br.ReadSingle();
+                    gdf.FireAmount = br.ReadInt32();
+                    float unk9 = br.ReadSingle();
+                    float unk10 = br.ReadSingle();
+                    gdf.AmmoCount = br.ReadInt32();
+                    float unk11 = br.ReadSingle();
+
+                    gdf.FireSpriteName = br.ReadCString(13);
+                    gdf.SoundName = br.ReadCString(13);
+                    if (rev == 8)
+                    {
+                        int unk12 = br.ReadInt32(); // Always 1?
+                        gdf.EnabledSpriteName = br.ReadCString(16);
+                        gdf.DisabledSpriteName = br.ReadCString(16);
+                    }
+                }
 
                 br.FindNext("GPOF"); // 192 bytes
-
-
+                for (int i = 0; i < 48; ++i)
+                {
+                    br.ReadSingle();
+                }
+                
                 br.FindNext("GGEO"); // 4 bytes
+                {
+                    int numParts = br.ReadInt32();
+                    gdf.Parts = new SdfPart[numParts];
+                    for (int i = 0; i < numParts; ++i)
+                    {
+                        SdfPart sdfPart = new SdfPart
+                        {
+                            Name = br.ReadCString(8),
+                            Right = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle()),
+                            Up = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle()),
+                            Forward = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle()),
+                            Position = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle()),
+                            ParentName = br.ReadCString(8)
+                        };
 
-
+                        gdf.Parts[i] = sdfPart;
+                        br.Position += 56;
+                    }
+                }
+                
                 br.FindNext("ORDF"); // 133 bytes
 
 

--- a/Assets/Scripts/System/Fileparsers/GdfParser.cs
+++ b/Assets/Scripts/System/Fileparsers/GdfParser.cs
@@ -81,7 +81,7 @@ namespace Assets.Fileparsers
                         };
 
                         gdf.Parts[i] = sdfPart;
-                        br.Position += 56;
+                        br.Position += 36;
                     }
                 }
                 

--- a/Assets/Scripts/System/Fileparsers/GdfParser.cs
+++ b/Assets/Scripts/System/Fileparsers/GdfParser.cs
@@ -21,7 +21,7 @@ namespace Assets.Fileparsers
     
     public class GdfParser
     {
-        public static Gdf ParseGdf(string filename, int mountPoint)
+        public static Gdf ParseGdf(string filename)
         {
             using (var br = new Bwd2Reader(filename))
             {

--- a/Assets/Scripts/System/Fileparsers/GdfParser.cs.meta
+++ b/Assets/Scripts/System/Fileparsers/GdfParser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7921edfbe76f2a842adc0d53f137e01b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/System/Fileparsers/VcfParser.cs
+++ b/Assets/Scripts/System/Fileparsers/VcfParser.cs
@@ -37,17 +37,9 @@ namespace Assets.Fileparsers
 
         public class VcfWeapon
         {
-            public MountPoint MountPoint { get; set; }
+            public int MountPoint { get; set; }
             public string GdfFilename { get; set; }
             public Gdf Gdf { get; set; }
-        }
-
-        public enum MountPoint : uint
-        {
-            Dropper,
-            FirstTop,
-            Rear,
-            SecondTop
         }
 
         public static Vcf ParseVcf(string filename)
@@ -82,7 +74,7 @@ namespace Assets.Fileparsers
                 {
                     var vcfWeapon = new VcfWeapon
                     {
-                        MountPoint = (MountPoint)br.ReadUInt32(),
+                        MountPoint = br.ReadInt32(),
                         GdfFilename = br.ReadCString(13)
                     };
 

--- a/Assets/Scripts/System/Fileparsers/VcfParser.cs
+++ b/Assets/Scripts/System/Fileparsers/VcfParser.cs
@@ -39,6 +39,7 @@ namespace Assets.Fileparsers
         {
             public MountPoint MountPoint { get; set; }
             public string GdfFilename { get; set; }
+            public Gdf Gdf { get; set; }
         }
 
         public enum MountPoint : uint
@@ -84,6 +85,9 @@ namespace Assets.Fileparsers
                         MountPoint = (MountPoint)br.ReadUInt32(),
                         GdfFilename = br.ReadCString(13)
                     };
+
+                    vcfWeapon.Gdf = GdfParser.ParseGdf(vcfWeapon.GdfFilename);
+
                     vcf.Weapons.Add(vcfWeapon);
                     br.Next();
                 }

--- a/Assets/Scripts/System/Fileparsers/VdfParser.cs
+++ b/Assets/Scripts/System/Fileparsers/VdfParser.cs
@@ -33,9 +33,19 @@ namespace Assets.Fileparsers
         public Vector3 Forward { get; set; }
         public Vector3 Position { get; set; }
         public float Unk { get; set; }
+        public uint HardpointIndex { get; set; }
         public uint Num1 { get; set; }
-        public uint Num2 { get; set; }
-        public uint Num3 { get; set; }
+        public HardpointMeshType MeshType { get; set; }
+    }
+
+    public enum HardpointMeshType : byte
+    {
+        None,
+        Top,
+        Side,
+        Turret,
+        Dropper,
+        Inside
     }
 
     public class Vdf
@@ -192,9 +202,9 @@ namespace Assets.Fileparsers
                     var hloc = new HLoc
                     {
                         Label = br.ReadCString(16),
+                        HardpointIndex = br.ReadUInt32(),
                         Num1 = br.ReadUInt32(),
-                        Num2 = br.ReadUInt32(),
-                        Num3 = br.ReadUInt32(),
+                        MeshType = (HardpointMeshType)br.ReadUInt32(),
                         Right = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle()),
                         Up = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle()),
                         Forward = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle()),

--- a/Assets/Scripts/System/LevelLoader.cs
+++ b/Assets/Scripts/System/LevelLoader.cs
@@ -77,6 +77,13 @@ namespace Assets.System
                         {
                             var lblUpper = odef.Label.ToUpper();
                             
+                            // Training mission uses hardcoded VCF for player.
+                            string vcfName = odef.Label;
+                            if (msnFilename.ToLower() == "a01.msn" && vcfName == "vppirna1")
+                            {
+                                vcfName = "vppa01";
+                            }
+
                             switch (lblUpper)
                             {
                                 case "SPAWN":
@@ -88,7 +95,7 @@ namespace Assets.System
                                     go.tag = "Regen";
                                     break;
                                 default:
-                                    go = cacheManager.ImportVcf(odef.Label + ".vcf", odef.TeamId == 1);
+                                    go = cacheManager.ImportVcf(vcfName + ".vcf", odef.TeamId == 1);
                                     break;
                             }
 

--- a/Assets/Shaders/CarWeaponZBias.shader
+++ b/Assets/Shaders/CarWeaponZBias.shader
@@ -1,0 +1,39 @@
+﻿Shader "Custom/CutOutWithoutZ" 
+{
+	Properties 
+	{
+		_Color ("Main Color", Color) = (1,1,1,1)
+		_MainTex ("Base (RGB) Trans (A)", 2D) = "white" {}
+		_Cutoff ("Alpha cutoff", Range(0,1)) = 0.5
+	}
+
+	SubShader 
+	{
+		Tags {"Queue"="AlphaTest" "IgnoreProjector"="True" "RenderType"="TransparentCutout"}
+		LOD 200
+		ZWrite Off
+		ZTest Always
+
+		CGPROGRAM
+		#pragma surface surf Lambert alphatest:_Cutoff
+
+		sampler2D _MainTex;
+		fixed4 _Color;
+
+		struct Input
+		{
+			float2 uv_MainTex;
+		};
+
+		void surf (Input IN, inout SurfaceOutput o)
+		{
+			fixed4 c = tex2D(_MainTex, IN.uv_MainTex) * _Color;
+			o.Albedo = c.rgb;
+			o.Alpha = c.a;
+		}
+
+		ENDCG
+	}
+
+	Fallback "Legacy Shaders/Transparent/Cutout/VertexLit"
+}

--- a/Assets/Shaders/CarWeaponZBias.shader.meta
+++ b/Assets/Shaders/CarWeaponZBias.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 1866f839ef280ac49bf23a16cb16a1af
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Should resolve Issue **#13 - Load Car Components**.

Highlights:
* Most of the data in the GDF files is parsed - this includes most of the useful info such as weapon ammo count, firing rate and weapon sounds.
* Correct weapon geometry is loaded based on vehicle hardpoint type (e.g. 'inside' and 'side' weapons load a different mesh than weapons placed on the roof).
* 'Inside' weapons (i.e. front weapons in screenshot below) use a shader with depth testing disabled. This should not cause any rendering issues because they're not visible from behind and they appear to be 2D anyway.

Don't get too excited though, weapons don't fire yet 😞.

![image](https://user-images.githubusercontent.com/1758130/44137288-3272bbde-a0b3-11e8-85d6-48aa96b5c22b.png)